### PR TITLE
Tab width configuration

### DIFF
--- a/jsstyle
+++ b/jsstyle
@@ -55,7 +55,7 @@ use Getopt::Std;
 use strict;
 
 my $usage =
-"usage: jsstyle [-chvC] [-t <num>][-o constructs] file ...
+"usage: jsstyle [-chvC] [-t <num>] [-o constructs] file ...
 	-c	check continuation indentation inside functions
 	-h	perform heuristic checks that are sometimes wrong
 	-t	specify tab width for line length calculation


### PR DESCRIPTION
The calculation of a line not exceeding 80 characters assumes that tabs are set to 8 spaces. It'd be nice if this could be a configurable parameter, such that the line width considers tabs as 4, or even 2, spaces.
