### PR TITLE
Avoid false positives in a regex quantifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ configurability.
                             "missing blank after start comment" check.
 
 
+## "JSSTYLED"-comments
+
+When you want `jsstyle` to ignore a line, you can use this:
+
+    /* JSSTYLED */
+    ignore = this + line;
+
+Or for a block:
+
+    /* BEGIN JSSTYLED */
+    var here
+      , be
+      , some = funky
+      , style
+    /* END JSSTYLED */
+
 
 ## License
 

--- a/jsstyle
+++ b/jsstyle
@@ -561,7 +561,9 @@ line: while (<$filehandle>) {
 			err("missing space around assignment operator");
 		}
 	}
-	if (/[,;]\S/ && !/\bfor \(;;\)/) {
+	if (/[,;]\S/ && !/\bfor \(;;\)/ &&
+	    # Allow a comma in a regex quantifier.
+	    !/\/.*?\{\d+,?\d*\}.*?\//) {
 		err("comma or semicolon followed by non-blank");
 	}
 	# allow "for" statements to have empty "while" clauses
@@ -620,7 +622,9 @@ line: while (<$filehandle>) {
 	if (/^\s*\(void\)[^ ]/) {
 		err("missing space after (void) cast");
 	}
-	if (/\S{/ && !/({|\(){/) {
+	if (/\S{/ && !/({|\(){/ &&
+	    # Allow a brace in a regex quantifier.
+	    !/\/.*?\{\d+,?\d*\}.*?\//) {
 		err("missing space before left brace");
 	}
 	if ($in_function && /^\s+{/ &&


### PR DESCRIPTION
Avoid false positives in a regex quantifier: 'comma or semicolon
followed by non-blank' and 'missing space before left brace'.

Also document JSSTYLED comments in readme.

```
$ cat foo.js 
var FIELD_REGEX = /^[a-zA-Z][\w._-]{2,}$/;
$ ./jsstyle foo.js 
foo.js: 1: comma or semicolon followed by non-blank
foo.js: 1: missing space before left brace
```
