### PR TITLE
Add some accommodation for more style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ configurability.
                             This is legacy. Does anyone use this?
     indent=<NUM|tab>        An integer number of spaces for indentation, or
                             'tab' for tab indentation (the default).
+    strict-indent           Boolean option, set to 1 to force indents of spaces
+                            to be a multiple of indent parameter.
     literal-string-quote    'single' (the default) or 'double'. Specifies
                             the preferred quote character for literal strings.
     unparenthesized-return  Boolean option, set to 0 to disable the
@@ -60,7 +62,10 @@ configurability.
     blank-after-start-comment
                             Boolean option, set to 0 to disable the
                             "missing blank after start comment" check.
-
+    continuation-at-front   Boolean option, set to 1 to force continations
+                            to be at the beginning rather than end of line.
+    leading-right-paren-ok  Boolean option, set to 1 to allow ) to start a
+                            line.
 
 ## "JSSTYLED"-comments
 

--- a/jsstyle
+++ b/jsstyle
@@ -108,7 +108,8 @@ my %config = (
 	"literal-string-quote" => "single",  # 'single' or 'double'
 	"blank-after-start-comment" => 1,
 	"continuation-at-front" => 0,
-	"right-paren-ok" => 0
+	"leading-right-paren-ok" => 0,
+	"strict-indent" => 0
 );
 sub add_config_var ($$) {
 	my ($scope, $str) = @_;
@@ -131,7 +132,8 @@ sub add_config_var ($$) {
 		 $name eq "splint" ||
 		 $name eq "unparenthesized-return" ||
 		 $name eq "continuation-at-front" ||
-		 $name eq "right-paren-ok" ||
+		 $name eq "leading-right-paren-ok" ||
+		 $name eq "strict-indent" ||
 		 $name eq "blank-after-start-comment") {
 
 		if ($value != 1 && $value != 0) {
@@ -489,7 +491,8 @@ line: while (<$filehandle>) {
 		if (length($indent) < $config{"indent"}) {
 			err("indent of " . length($indent) .
 				" space(s) instead of " . $config{"indent"});
-		} elsif (length($indent) % $config{"indent"} != 0) {
+		} elsif ($config{"strict-indent"} &&
+			length($indent) % $config{"indent"} != 0) {
 			err("indent is " . length($indent) .
 				" not a multiple of " . $config{'indent'} . " spaces");
 		}
@@ -586,7 +589,9 @@ line: while (<$filehandle>) {
 	if (/\S   *(&&|\|\|)/ || /(&&|\|\|)   *\S/) {
 		err("more than one space around boolean operator");
 	}
-	if (/\s(delete|typeof|instanceOf|throw|with|catch|new|function|in|for|if|while|switch|return|case)\(/) {
+	# We allow methods which look like obj.delete() but not keywords without
+	# spaces ala: delete(obj)
+	if (/(?<!\.)\b(delete|typeof|instanceof|throw|with|catch|new|function|in|for|if|while|switch|return|case)\(/) {
 		err("missing space between keyword and paren");
 	}
 	if (/(\b(catch|for|if|with|while|switch|return)\b.*){2,}/) {
@@ -627,7 +632,7 @@ line: while (<$filehandle>) {
 	}
 	# allow "for" statements to have empty "continue" clauses
 	if (/\s\)/ && !/^\s*for \([^;]*;[^;]*; \)/) {
-		if ($config{"right-paren-ok"} && /^\s+\)/) {
+		if ($config{"leading-right-paren-ok"} && /^\s+\)/) {
 			# this is allowed
 		} else {
 			err("whitespace before right paren");


### PR DESCRIPTION
This adds:
- strict-indent option which forces indenting to be a multiple of indent (ie. indent=4, indents cannot be 7)
- continuation-at-front which allows for continuations to start at the front of the line instead of being at the end:
  
  if (...
        && ...
        || ...
            + ...) {
- leading-right-paren-ok which allows a line to start with: )

It also fixes an issue where an object has a member named 'delete' and you want to call obj.delete which was previously breaking on the space after keyword check.
