### PR TITLE
Allow common style for anonymous function (wihout blank before paren)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ configurability.
     blank-after-open-comment
                             Boolean option, set to 0 to disable the
                             "missing blank after open comment" check. `/* */`
+    no-blank-for-anon-function
+                            Boolean option, set to 1 to allow anonymous
+                            functions without blank before paren. `function() { ... }`
     continuation-at-front   Boolean option, set to 1 to force continations
                             to be at the beginning rather than end of line.
     leading-right-paren-ok  Boolean option, set to 1 to allow ) to start a

--- a/jsstyle
+++ b/jsstyle
@@ -108,6 +108,7 @@ my %config = (
 	"literal-string-quote" => "single",  # 'single' or 'double'
 	"blank-after-start-comment" => 1,
 	"blank-after-open-comment" => 1,
+    "no-blank-for-anon-function" => 0,
 	"continuation-at-front" => 0,
 	"leading-right-paren-ok" => 0,
 	"strict-indent" => 0
@@ -139,7 +140,8 @@ sub add_config_var ($$) {
 		 $name eq "whitespace-after-left-paren-ok" ||
 		 $name eq "strict-indent" ||
 		 $name eq "blank-after-open-comment" ||
-		 $name eq "blank-after-start-comment") {
+		 $name eq "blank-after-start-comment" ||
+         $name eq "no-blank-for-anon-function") {
 
 		if ($value != 1 && $value != 0) {
 			die "$scope: invalid '$name': don't give a value";
@@ -601,7 +603,10 @@ line: while (<$filehandle>) {
 	}
 	# We allow methods which look like obj.delete() but not keywords without
 	# spaces ala: delete(obj)
-	if (/(?<!\.)\b(delete|typeof|instanceof|throw|with|catch|new|function|in|for|if|while|switch|return|case)\(/) {
+	if (!$config{"no-blank-for-anon-function"} && /(?<!\.)\bfunction\(/) {
+		err("missing space between 'function' and paren");
+	}
+	if (/(?<!\.)\b(delete|typeof|instanceof|throw|with|catch|new|in|for|if|while|switch|return|case)\(/) {
 		err("missing space between keyword and paren");
 	}
 	if (/(\b(catch|for|if|with|while|switch|return)\b.*){2,}/) {

--- a/jsstyle
+++ b/jsstyle
@@ -108,7 +108,7 @@ my %config = (
 	"literal-string-quote" => "single",  # 'single' or 'double'
 	"blank-after-start-comment" => 1,
 	"blank-after-open-comment" => 1,
-    "no-blank-for-anon-function" => 0,
+	"no-blank-for-anon-function" => 0,
 	"continuation-at-front" => 0,
 	"leading-right-paren-ok" => 0,
 	"strict-indent" => 0
@@ -141,7 +141,7 @@ sub add_config_var ($$) {
 		 $name eq "strict-indent" ||
 		 $name eq "blank-after-open-comment" ||
 		 $name eq "blank-after-start-comment" ||
-         $name eq "no-blank-for-anon-function") {
+		 $name eq "no-blank-for-anon-function") {
 
 		if ($value != 1 && $value != 0) {
 			die "$scope: invalid '$name': don't give a value";

--- a/jsstyle
+++ b/jsstyle
@@ -605,6 +605,8 @@ line: while (<$filehandle>) {
 	# spaces ala: delete(obj)
 	if (!$config{"no-blank-for-anon-function"} && /(?<!\.)\bfunction\(/) {
 		err("missing space between 'function' and paren");
+	} elsif ($config{"no-blank-for-anon-function"} && /(?<!\.)\bfunction\s+\(/) {
+		err("space between 'function' and paren");
 	}
 	if (/(?<!\.)\b(delete|typeof|instanceof|throw|with|catch|new|in|for|if|while|switch|return|case)\(/) {
 		err("missing space between keyword and paren");


### PR DESCRIPTION
The new option allows people to use this very common style to write anonymous function like that:

``` javascript
var myfunct = function() { // note there is no space between 'function' and '()'
    ...
}
```
